### PR TITLE
ヘッダーのコース名を置き換える機能を実装

### DIFF
--- a/src/content_scripts/allPages/allPages.ts
+++ b/src/content_scripts/allPages/allPages.ts
@@ -1,11 +1,13 @@
 import removeForceDownload from './removeForceDownload.ts';
 import replaceNavigationText from './replaceNavigationText.ts';
+import replaceHeaderCourseName from './replaceHeaderCourseName.ts';
 
 globalThis.addEventListener('load', async () => {
   console.log('Extension loaded.');
 
   await Promise.all([
     replaceNavigationText.loader(),
-    await removeForceDownload.loader(),
+    replaceHeaderCourseName.loader(),
+    removeForceDownload.loader(),
   ]);
 });

--- a/src/content_scripts/allPages/replaceHeaderCourseName.ts
+++ b/src/content_scripts/allPages/replaceHeaderCourseName.ts
@@ -1,0 +1,42 @@
+import type { Feature } from '../common/types.ts';
+import { getCourses } from '../../common/storage/course.ts';
+
+/** ヘッダーのコース表示名をわかりやすい表示に変更する */
+const replaceHeaderCourseName: Feature<void, void> = {
+  uniqueName: 'all-pages-replace-header-course-name',
+  hostnameFilter: 'cms7.ict.nitech.ac.jp',
+  pathnameFilter: /^\/moodle40a\//,
+  loader: async () => {
+    const elHeader = document.getElementById('page-header');
+    if (!elHeader) {
+      return;
+    }
+
+    const courses = await getCourses();
+    const courseNameMap = new Map<string, string>();
+    for (const course of courses) {
+      if (course.type === 'regular-lecture') {
+        courseNameMap.set(
+          course.shortName,
+          `${course.name} ${course.shortName}`,
+        );
+      } else {
+        courseNameMap.set(course.shortName, course.fullName);
+      }
+    }
+
+    const elBreadcrumbLinks = elHeader.querySelectorAll<HTMLElement>(
+      'nav li a',
+    );
+    elBreadcrumbLinks.forEach((elLink) => {
+      const shortName = elLink.textContent ?? '';
+      const courseName = courseNameMap.get(shortName);
+
+      if (typeof courseName === 'string') {
+        elLink.textContent = courseName;
+      }
+    });
+  },
+};
+
+export default replaceHeaderCourseName;

--- a/src/manifest.json5
+++ b/src/manifest.json5
@@ -2,7 +2,7 @@
   // Required
   manifest_version: 3,
   name: "NITech Moodle Extension (40a)",
-  version: "0.6.0",
+  version: "0.7.0",
 
   // Recommended
   // action: {},


### PR DESCRIPTION
- ヘッダーのコース名を置き換える機能を実装
  - `xx-x-xxxx` のような表示を `コース名 xx-x-xxxx` のような表示に変更する