### PR TITLE
Import maps を web accessible resources に追加

### DIFF
--- a/src/manifest.json5
+++ b/src/manifest.json5
@@ -2,7 +2,7 @@
   // Required
   manifest_version: 3,
   name: "NITech Moodle Extension (40a)",
-  version: "0.8.2",
+  version: "0.8.3",
 
   // Recommended
   // action: {},

--- a/src/manifest.json5
+++ b/src/manifest.json5
@@ -60,4 +60,15 @@
   },
   permissions: ["background", "storage"],
   host_permissions: ["https://cms7.ict.nitech.ac.jp/moodle40a/*/*"],
+  web_accessible_resources: [
+    // import maps
+    {
+      resources: [
+        "content_scripts/allPages/allPages.js.map",
+        "content_scripts/dashboard/dashboard.js.map",
+        "content_scripts/scorm/scorm.js.map",
+      ],
+      matches: [ "<all_urls>" ],
+    },
+  ],
 }

--- a/src/manifest.json5
+++ b/src/manifest.json5
@@ -64,9 +64,7 @@
     // import maps
     {
       resources: [
-        "content_scripts/allPages/allPages.js.map",
-        "content_scripts/dashboard/dashboard.js.map",
-        "content_scripts/scorm/scorm.js.map",
+        "content_scripts/*/*.map",
       ],
       matches: [ "<all_urls>" ],
     },


### PR DESCRIPTION
- ログにバンドル前のファイル名が表示されるように import map の読み込みをできるようにする必要
  - import map は `manifest.json` の `web_accessible_resources` に設定されていないと読み込みができない