### PR TITLE
manifest.json の出力を修正 #42

### DIFF
--- a/esbuild.common.ts
+++ b/esbuild.common.ts
@@ -34,8 +34,8 @@ const contentStyleSheets = Array.from(new Set(
 
 const optionsResources = [
   manifest['options_ui']['page'],
-  ...manifest['options_ui']['js'].map((path) => path.replace(/\.js$/, '.ts')),
-  ...manifest['options_ui']['css'].map((path) => path.replace(/\.css$/, '.scss')),
+  ...(manifest['options_ui']['js'] ?? []).map((path) => path.replace(/\.js$/, '.ts')),
+  ...(manifest['options_ui']['css'] ?? []).map((path) => path.replace(/\.css$/, '.scss')),
 ].map((path) => posix.resolve(srcPath, path));
 
 const config: Partial<esbuild.BuildOptions> = {

--- a/plugins/objectExportJSON.ts
+++ b/plugins/objectExportJSON.ts
@@ -1,0 +1,27 @@
+import * as esbuild from 'esbuild';
+import * as posix from 'posix';
+import * as fs from 'std/fs/mod.ts';
+
+interface Option {
+  targets: { value: any, filename: string }[]
+}
+
+const objectExportJSONPlugin = (option: Option): esbuild.Plugin => ({
+  name: 'object-export-json-plugin',
+  setup(build) {
+    build.onStart(async () => {
+      const writePromises: Promise<void>[] = [];
+
+      for(const target of option.targets) {
+        const content = JSON.stringify(target.value);
+
+        writePromises.push(fs.ensureDir(posix.dirname(target.filename))
+          .then(() => Deno.writeTextFile(target.filename, content)));
+      }
+
+      await Promise.all(writePromises);
+    });
+  }
+});
+
+export default objectExportJSONPlugin;

--- a/src/manifest.json5
+++ b/src/manifest.json5
@@ -3,7 +3,7 @@
   manifest_version: 3,
   name: "NITech Moodle Extension (40a)",
   homepage_url: "https://github.com/nitech-create/nitech-moodle-extension-40a",
-  version: "0.9.5",
+  version: "0.9.6",
 
   // Recommended
   // action: {},

--- a/src/manifestType.ts
+++ b/src/manifestType.ts
@@ -24,8 +24,10 @@ export default interface ManifestType {
   };
   options_ui: {
     page: string;
-    js: string[];
-    css: string[];
+    open_in_tab: boolean;
+    browser_style: boolean;
+    js?: string[];
+    css?: string[];
   };
 
   permissions: string[];


### PR DESCRIPTION
`manifest.json` の出力からビルド用フィールドを取り除くように変更 (fix #42)

- もともと JSON5 用の読み込みと単体ファイル書き出しプラグインを作成していたが、オブジェクトを JSON として出力するプラグインに切り替え
- `manifest.json5` をパースした後該当フィールドを削除してプラグインを用いて出力