### PR TITLE
import assertion を import attributes に変更

### DIFF
--- a/.github/workflows/lint-fmt-test.yml
+++ b/.github/workflows/lint-fmt-test.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Lint
         run: deno lint

--- a/esbuild.common.ts
+++ b/esbuild.common.ts
@@ -2,8 +2,8 @@ import * as esbuild from 'esbuild';
 import { posix } from 'posix';
 import JSON5 from 'json5';
 import type ManifestType from './src/manifestType.ts';
-import denoConfig from './deno.json' assert { type: 'json' };
-import importmap from './import_map.json' assert { type: 'json' };
+import denoConfig from './deno.json' with { type: 'json' };
+import importmap from './import_map.json' with { type: 'json' };
 
 import sassPlugin from 'esbuild-plugin-sass';
 import { esbuildCachePlugin } from 'esbuild-cache-plugin';
@@ -16,25 +16,33 @@ const destPath = 'dist';
 const cachePath = 'cache';
 
 const manifest = JSON5.parse(
-  Deno.readTextFileSync(posix.resolve(srcPath, 'manifest.json5'))
+  Deno.readTextFileSync(posix.resolve(srcPath, 'manifest.json5')),
 ) as ManifestType;
 
-const contentScripts = Array.from(new Set(
-  manifest['content_scripts']
-    .flatMap((entry) => entry['js'] ?? [])
-    .map((path) => posix.resolve(srcPath, path.replace(/\.js$/, '.ts')))
-));
+const contentScripts = Array.from(
+  new Set(
+    manifest['content_scripts']
+      .flatMap((entry) => entry['js'] ?? [])
+      .map((path) => posix.resolve(srcPath, path.replace(/\.js$/, '.ts'))),
+  ),
+);
 
-const contentStyleSheets = Array.from(new Set(
-  manifest['content_scripts']
-    .flatMap((entry) => entry['css'] ?? [])
-    .map((path) => posix.resolve(srcPath, path.replace(/\.css$/, '.scss')))
-));
+const contentStyleSheets = Array.from(
+  new Set(
+    manifest['content_scripts']
+      .flatMap((entry) => entry['css'] ?? [])
+      .map((path) => posix.resolve(srcPath, path.replace(/\.css$/, '.scss'))),
+  ),
+);
 
 const optionsResources = [
   manifest['options_ui']['page'],
-  ...(manifest['options_ui']['js'] ?? []).map((path) => path.replace(/\.js$/, '.ts')),
-  ...(manifest['options_ui']['css'] ?? []).map((path) => path.replace(/\.css$/, '.scss')),
+  ...(manifest['options_ui']['js'] ?? []).map((path) =>
+    path.replace(/\.js$/, '.ts')
+  ),
+  ...(manifest['options_ui']['css'] ?? []).map((path) =>
+    path.replace(/\.css$/, '.scss')
+  ),
 ].map((path) => posix.resolve(srcPath, path));
 
 // Reflect.deleteProperty と違って Typescript の型チェックが効く
@@ -71,13 +79,14 @@ const config: Partial<esbuild.BuildOptions> = {
       baseOutDir: destPath,
       files: [
         { from: 'imgs/*', to: 'imgs/[name][ext]' },
-      ]
+      ],
     }),
     resultPlugin(),
   ],
   logOverride: {
     'unsupported-jsx-comment': 'silent',
   },
-}
+};
 
 export default config;
+


### PR DESCRIPTION
## 概要

- import assertion (`import ... assert ...`) を [import attributes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with) (`import ... with ...`) に置き換え
- GitHub Actions で使用する Deno のバージョンを 2.x に変更

### 捕捉

- ビルドは通るようになりましたが諸般の事情で lint, format はめちゃめちゃ落ちる
  - これは [`refactor` ブランチ](https://github.com/nitech-create/nitech-moodle-extension-40a/tree/refactor) で今後直す予定
  - ひとまずエラーを解消してビルドを通せるようにするための PR

## 理由

Deno 2.0 以降では import assertion はサポートされないためビルド時にランタイムエラーが発生するため

## 背景

- Deno 1.x では import assertion (当時は proposal だった) が使われていた
- Deno 2.0 以降では import assertion は廃止されて変わりに標準になった import attributes に置き換わった